### PR TITLE
No longer refer to orno/di

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Total Downloads](https://poser.pugx.org/league/di/downloads.png)](https://packagist.org/packages/league/di)
 [![Latest Stable Version](https://poser.pugx.org/league/di/v/stable.png)](https://packagist.org/packages/league/di)
 
-_**DEPRECATED: Use [Orno\Di](https://github.com/orno/di) instead as the two are incredibly similar, and theirs is more actively developed.**_
+_**DEPRECATED: Use [league/container](https://github.com/thephpleague/container) instead as the two are incredibly similar, and the other one is more actively developed.**_
 
 The League\Di library provides a fast and powerful Dependency Injection Container for your application.
 


### PR DESCRIPTION
I talked to someone yesterday who was really confused because this one pointed to orno/di and orno/di pointed back to the league, though to a different package, but that wasn't clear to that person on first sight.
